### PR TITLE
Updated electron-prebuilt to version 0.33.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "author": "Ben Evans <ben@bensbit.co.uk> (http://bensbit.co.uk)",
   "license": "ISC",
   "dependencies": {
-    "electron-prebuilt": "0.31.2"
+    "electron-prebuilt": "0.33.4"
   }
 }


### PR DESCRIPTION
:rocket:

electron-prebuilt just published version 0.33.4, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

[GitHub Release](https://github.com/mafintosh/electron-prebuilt/releases/tag/v0.33.4)

0.33.4

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
